### PR TITLE
feat: backoff strategy retries also for 502 and 504 error codes

### DIFF
--- a/src/Keboola/Provisioning/ApiCallBackoffStrategy.php
+++ b/src/Keboola/Provisioning/ApiCallBackoffStrategy.php
@@ -10,15 +10,15 @@ use Guzzle\Plugin\Backoff\AbstractErrorCodeBackoffStrategy;
 /**
  * Strategy used to retry HTTP requests based on the response code.
  *
- * Retries 500 and 503 error by default.
+ * Retries 500, 502, 503 and 504 errors by default.
  */
-class MaintenanceBackoffStrategy extends AbstractErrorCodeBackoffStrategy
+class ApiCallBackoffStrategy extends AbstractErrorCodeBackoffStrategy
 {
     /** @var array Default HTTP codes errors to retry */
-    protected static $defaultErrorCodes = array(503, 500);
+    protected static $defaultErrorCodes = array(502, 503, 504, 500);
 
     /** @var array Default HTTP codes errors to retry */
-    protected static $defaultRetryAfter = 60;
+    protected static $defaultRetryAfter = 5;
 
     protected function getDelay($retries, RequestInterface $request, Response $response = null, HttpException $e = null)
     {

--- a/src/Keboola/Provisioning/ApiCallBackoffStrategy.php
+++ b/src/Keboola/Provisioning/ApiCallBackoffStrategy.php
@@ -15,7 +15,7 @@ use Guzzle\Plugin\Backoff\AbstractErrorCodeBackoffStrategy;
 class ApiCallBackoffStrategy extends AbstractErrorCodeBackoffStrategy
 {
     /** @var array Default HTTP codes errors to retry */
-    protected static $defaultErrorCodes = array(502, 503, 504, 500);
+    protected static $defaultErrorCodes = array(500, 502, 503, 504);
 
     /** @var array Default HTTP codes errors to retry */
     protected static $defaultRetryAfter = 60;

--- a/src/Keboola/Provisioning/ApiCallBackoffStrategy.php
+++ b/src/Keboola/Provisioning/ApiCallBackoffStrategy.php
@@ -18,7 +18,7 @@ class ApiCallBackoffStrategy extends AbstractErrorCodeBackoffStrategy
     protected static $defaultErrorCodes = array(502, 503, 504, 500);
 
     /** @var array Default HTTP codes errors to retry */
-    protected static $defaultRetryAfter = 5;
+    protected static $defaultRetryAfter = 60;
 
     protected function getDelay($retries, RequestInterface $request, Response $response = null, HttpException $e = null)
     {

--- a/src/Keboola/Provisioning/Client.php
+++ b/src/Keboola/Provisioning/Client.php
@@ -81,16 +81,16 @@ class Client
 			CURLOPT_TIMEOUT => $this->timeout
 		));
 
-        $maintenanceBackoff = new BackoffPlugin(
+        $retryStrategy = new BackoffPlugin(
             new TruncatedBackoffStrategy(10,
-                new MaintenanceBackoffStrategy(array(503),
+                new ApiCallBackoffStrategy(ApiCallBackoffStrategy::getDefaultFailureCodes(),
                     new CurlBackoffStrategy(CurlBackoffStrategy::getDefaultFailureCodes(),
                         new ExponentialBackoffStrategy()
                     )
                 )
             )
         );
-        $client->addSubscriber($maintenanceBackoff);
+        $client->addSubscriber($retryStrategy);
 
 		$this->client = $client;
         $syrupUrl = substr($url, 0, strrpos($url, '/'));


### PR DESCRIPTION
FIXES #17 

- `MaintenanceBackoffStrategy` přejmenovávám na `ApiCallBackoffStrategy` (už nedělá jen maintenance)
- všechny chybový kódy, který má poskytnout, se nastaví skrz `ApiCallBackoffStrategy::getDefaultFailureCodes()`
- proměnná se přejmenovala z `$maintenanceBackoff` na `$retryStrategy`
- není to testované (měl bych to přidat?)