### PR TITLE
Make storage api url configurable

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -8,6 +8,9 @@ if (file_exists(ROOT_PATH . '/config.php')) {
 	require_once ROOT_PATH . '/config.php';
 }
 
+defined('STORAGE_API_URL')
+	|| define('STORAGE_API_URL', getenv('STORAGE_API_URL') ? getenv('STORAGE_API_URL') : 'url');
+
 defined('PROVISIONING_API_URL')
 	|| define('PROVISIONING_API_URL', getenv('PROVISIONING_API_URL') ? getenv('PROVISIONING_API_URL') : 'url');
 

--- a/build.xml
+++ b/build.xml
@@ -128,6 +128,7 @@
 
 	<target name="tests-ci" depends="prepare" description="Run unit tests with PHPUnit">
 		<exec executable="phpunit" failonerror="true">
+            <env key="STORAGE_API_URL" value="${storage-api-url}"/>
             <env key="PROVISIONING_API_URL" value="${provisioning-api-url}"/>
             <env key="PROVISIONING_API_TOKEN" value="${provisioning-api-token}"/>
             <env key="PROVISIONING_API_TOKEN_SECOND_PROJECT" value="${provisioning-api-token-second-project}"/>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     tty: true
     stdin_open: true
     environment:
+      - STORAGE_API_URL
       - PROVISIONING_API_URL
       - SYRUP_QUEUE_URL
       - PROVISIONING_API_TOKEN

--- a/tests/Keboola/Provisioning/Client/JupyterTest.php
+++ b/tests/Keboola/Provisioning/Client/JupyterTest.php
@@ -84,7 +84,10 @@ class Keboola_ProvisioningClient_JupyterTest extends \ProvisioningTestCase
 
     public function testCreatePythonTransformationCredentials()
     {
-        $client = new \Keboola\StorageApi\Client(['token' => PROVISIONING_API_TOKEN]);
+        $client = new \Keboola\StorageApi\Client([
+            'url' => STORAGE_API_URL,
+            'token' => PROVISIONING_API_TOKEN
+        ]);
         $components = new \Keboola\StorageApi\Components($client);
         $config = new Configuration();
         $config->setName('test-config');

--- a/tests/Keboola/Provisioning/Client/RStudioTest.php
+++ b/tests/Keboola/Provisioning/Client/RStudioTest.php
@@ -84,7 +84,10 @@ class Keboola_ProvisioningClient_RStudioTest extends \ProvisioningTestCase
 
     public function testCreateRTransformationCredentials()
     {
-        $client = new \Keboola\StorageApi\Client(['token' => PROVISIONING_API_TOKEN]);
+        $client = new \Keboola\StorageApi\Client([
+            'url' => STORAGE_API_URL,
+            'token' => PROVISIONING_API_TOKEN
+        ]);
         $components = new \Keboola\StorageApi\Components($client);
         $config = new Configuration();
         $config->setName('test-config');

--- a/tests/Keboola/Provisioning/Client/RedshiftWorkspaceTest.php
+++ b/tests/Keboola/Provisioning/Client/RedshiftWorkspaceTest.php
@@ -282,7 +282,10 @@ class Keboola_ProvisioningClient_RedshiftWorkspaceTest extends \ProvisioningTest
     {
         $result = $this->client->getCredentials();
         $workspaceId = $result["workspaceId"];
-        $storageApiClient = new \Keboola\StorageApi\Client(["token" => PROVISIONING_API_TOKEN]);
+        $storageApiClient = new \Keboola\StorageApi\Client([
+            'url' => STORAGE_API_URL,
+            'token' => PROVISIONING_API_TOKEN
+        ]);
         $storageApiClient->apiDelete("storage/workspaces/{$workspaceId}");
         $result = $this->client->getCredentials();
         $this->assertNotEquals($result["workspaceId"], $workspaceId);

--- a/tests/Keboola/Provisioning/Client/SnowflakeTest.php
+++ b/tests/Keboola/Provisioning/Client/SnowflakeTest.php
@@ -296,7 +296,10 @@ class Keboola_ProvisioningClient_SnowflakeTest extends \ProvisioningTestCase
     {
         $result = $this->client->getCredentials();
         $workspaceId = $result["workspaceId"];
-        $storageApiClient = new \Keboola\StorageApi\Client(["token" => PROVISIONING_API_TOKEN]);
+        $storageApiClient = new \Keboola\StorageApi\Client([
+            'url' => STORAGE_API_URL,
+            'token' => PROVISIONING_API_TOKEN
+        ]);
         $storageApiClient->apiDelete("storage/workspaces/{$workspaceId}");
         $result = $this->client->getCredentials();
         $this->assertNotEquals($result["workspaceId"], $workspaceId);


### PR DESCRIPTION
Changes:

- new environment variable, updated related configurations (bootstrap.php, build.xml)
- pass `url` to every instance of storage api client