### PR TITLE
feat: workspace id as string

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -65,7 +65,7 @@ Create new credentials for given token or return existing credentials, if they a
 
         {
             "credentials": {
-                "id": "49",
+                "id": 49,
                 "hostname": "keboola.snowflakecomputing.com",
                 "port": null,
                 "db": "sapi_232",
@@ -75,7 +75,7 @@ Create new credentials for given token or return existing credentials, if they a
                 "password": "ZG7dHp5wUHXCzm5zu99uVRStvvuk4Bjb",
                 "workspaceId": "485895075"
             },
-            "id": "49",
+            "id": 49,
             "touch": 1551197297
             "url": "snowflake/49"
         }
@@ -104,9 +104,9 @@ Get available credentials for the given `type`. Useful when credentials id is no
 
         {
             "credentials": {
-                "id": "49",
+                "id": 49,
                 "hostname": "keboola.snowflakecomputing.com",
-                "port": null,
+                "port": 443,
                 "db": "sapi_232",
                 "schema": "WORKSPACE_485895075",
                 "warehouse": "KEBOOLA_PROD",
@@ -114,7 +114,7 @@ Get available credentials for the given `type`. Useful when credentials id is no
                 "password": "ZG7dHp5wUHXCzm5zu99uVRStvvuk4Bjb",
                 "workspaceId": "485895075"
             },
-            "id": "49",
+            "id": 49,
             "inUse": false,
             "touch": 1551197297
         }
@@ -142,9 +142,9 @@ Get available credentials for the given `type`. Useful when credentials id is no
 
         {
             "credentials": {
-                "id": "49",
+                "id": 49,
                 "hostname": "keboola.snowflakecomputing.com",
-                "port": null,
+                "port": 443,
                 "db": "sapi_232",
                 "schema": "WORKSPACE_485895075",
                 "warehouse": "KEBOOLA_PROD",
@@ -152,7 +152,7 @@ Get available credentials for the given `type`. Useful when credentials id is no
                 "password": "ZG7dHp5wUHXCzm5zu99uVRStvvuk4Bjb",
                 "workspaceId": "485895075"
             },
-            "id": "49",
+            "id": 49,
             "touch": 1551197297
             "inUse": false,
         }
@@ -212,8 +212,8 @@ Marks credentials as being used and resets the validity period.
 
 
         {
-            "touch": "123456",
-            "id": "1386700227"
+            "touch": 1551197297,
+            "id": 1386700227
         }
 
 
@@ -235,7 +235,7 @@ You need to call Provisioning API again to obtain details of the credentials.
 
 ```
 {
-    "id": 206296229,
+    "id": 43,
     "runId": "206296230",
     "component": "keboola-provisioning-bundle",
     "command": "create",
@@ -301,7 +301,7 @@ You need to call Provisioning API again to obtain details of the credentials.
 
 ```
 {
-    "id": 206296229,
+    "id": 43,
     "runId": "206296230",
     "component": "keboola-provisioning-bundle",
     "command": "create",
@@ -368,7 +368,7 @@ finished, the result will be contained in the `result` node.
 
 ```
 {
-    "id": 206298086,
+    "id": 43,
     "runId": "206298087",
     "component": "keboola-provisioning-bundle",
     "command": "delete",
@@ -392,7 +392,7 @@ finished, the result will be contained in the `result` node.
 + Response 200 (application/json)
 
         {
-            "id": "206298086",
+            "id": 43,
             "url": "http://syrup-queue.kbc-devel-02.keboola.com/app_dev.php/queue/job/206298086",
             "status": "waiting"
         }

--- a/apiary.apib
+++ b/apiary.apib
@@ -65,16 +65,19 @@ Create new credentials for given token or return existing credentials, if they a
 
         {
             "credentials": {
-                "db": "tapi_70_sand",
-                "hostname": "tapi-b.keboola.com",
-                "id": "1386700227",
-                "password": "0hoo4e35acszjxw6",
-                "user": "tapi_70_sand"
+                "id": "49",
+                "hostname": "keboola.snowflakecomputing.com",
+                "port": null,
+                "db": "sapi_232",
+                "schema": "WORKSPACE_485895075",
+                "warehouse": "KEBOOLA_PROD",
+                "user": "SAPI_WORKSPACE_485895075",
+                "password": "ZG7dHp5wUHXCzm5zu99uVRStvvuk4Bjb",
+                "workspaceId": "485895075"
             },
-            "id": "1386700227",
-            "status": "ok",
-            "touch": "123456"
-            "url": "snowflake/1386700227"
+            "id": "49",
+            "touch": 1551197297
+            "url": "snowflake/49"
         }
 
 ## List Credentials [/{backend}?type={type}]
@@ -100,17 +103,20 @@ Get available credentials for the given `type`. Useful when credentials id is no
 + Response 200 (application/json)
 
         {
-            "id": "1386700227",
             "credentials": {
-                "db": "tapi_70_sand",
-                "hostname": "tapi-b.keboola.com",
-                "id": "1386700227",
-                "password": "0hoo4e35acszjxw6",
-                "user": "tapi_70_sand"
+                "id": "49",
+                "hostname": "keboola.snowflakecomputing.com",
+                "port": null,
+                "db": "sapi_232",
+                "schema": "WORKSPACE_485895075",
+                "warehouse": "KEBOOLA_PROD",
+                "user": "SAPI_WORKSPACE_485895075",
+                "password": "ZG7dHp5wUHXCzm5zu99uVRStvvuk4Bjb",
+                "workspaceId": "485895075"
             },
+            "id": "49",
             "inUse": false,
-            "touch": "123456"
-            "status": "ok"
+            "touch": 1551197297
         }
 
 
@@ -135,17 +141,20 @@ Get available credentials for the given `type`. Useful when credentials id is no
 + Response 200 (application/json)
 
         {
-            "id": "1386700227",
             "credentials": {
-                "db": "tapi_70_sand",
-                "hostname": "tapi-b.keboola.com",
-                "id": "1386700227",
-                "password": "0hoo4e35acszjxw6",
-                "user": "tapi_70_sand"
+                "id": "49",
+                "hostname": "keboola.snowflakecomputing.com",
+                "port": null,
+                "db": "sapi_232",
+                "schema": "WORKSPACE_485895075",
+                "warehouse": "KEBOOLA_PROD",
+                "user": "SAPI_WORKSPACE_485895075",
+                "password": "ZG7dHp5wUHXCzm5zu99uVRStvvuk4Bjb",
+                "workspaceId": "485895075"
             },
+            "id": "49",
+            "touch": 1551197297
             "inUse": false,
-            "touch": "123456"
-            "status": "ok"
         }
 
 ### Drop Credentials Sync [DELETE]

--- a/tests/Keboola/Provisioning/Client/RedshiftWorkspaceTest.php
+++ b/tests/Keboola/Provisioning/Client/RedshiftWorkspaceTest.php
@@ -288,7 +288,7 @@ class Keboola_ProvisioningClient_RedshiftWorkspaceTest extends \ProvisioningTest
         ]);
         $storageApiClient->apiDelete("storage/workspaces/{$workspaceId}");
         $result = $this->client->getCredentials();
-        $this->assertNotEquals($result["workspaceId"], $workspaceId);
+        $this->assertNotEquals($result["credentials"]["workspaceId"], $workspaceId);
     }
 
     /**

--- a/tests/Keboola/Provisioning/Client/RedshiftWorkspaceTest.php
+++ b/tests/Keboola/Provisioning/Client/RedshiftWorkspaceTest.php
@@ -53,6 +53,9 @@ class Keboola_ProvisioningClient_RedshiftWorkspaceTest extends \ProvisioningTest
         $this->assertArrayHasKey("workspaceId", $result["credentials"]);
         $this->assertArrayHasKey("id", $result);
         $this->assertArrayHasKey("touch", $result);
+
+        $this->assertInternalType('string', $result["credentials"]["workspaceId"]);
+
         $conn = $this->connect($result["credentials"]);
         $this->dbQuery($conn);
         $conn->close();

--- a/tests/Keboola/Provisioning/Client/RedshiftWorkspaceTest.php
+++ b/tests/Keboola/Provisioning/Client/RedshiftWorkspaceTest.php
@@ -50,8 +50,8 @@ class Keboola_ProvisioningClient_RedshiftWorkspaceTest extends \ProvisioningTest
         $this->assertArrayHasKey("password", $result["credentials"]);
         $this->assertArrayHasKey("user", $result["credentials"]);
         $this->assertArrayHasKey("schema", $result["credentials"]);
+        $this->assertArrayHasKey("workspaceId", $result["credentials"]);
         $this->assertArrayHasKey("id", $result);
-        $this->assertArrayHasKey("workspaceId", $result);
         $this->assertArrayHasKey("touch", $result);
         $conn = $this->connect($result["credentials"]);
         $this->dbQuery($conn);
@@ -75,9 +75,9 @@ class Keboola_ProvisioningClient_RedshiftWorkspaceTest extends \ProvisioningTest
         $this->assertArrayHasKey("password", $result["credentials"]);
         $this->assertArrayHasKey("user", $result["credentials"]);
         $this->assertArrayHasKey("schema", $result["credentials"]);
+        $this->assertArrayHasKey("workspaceId", $result["credentials"]);
         $this->assertArrayHasKey("touch", $result);
         $this->assertArrayHasKey("id", $result);
-        $this->assertArrayHasKey("workspaceId", $result);
         $conn = $this->connect($result["credentials"]);
         $this->dbQuery($conn);
         $conn->close();
@@ -103,9 +103,9 @@ class Keboola_ProvisioningClient_RedshiftWorkspaceTest extends \ProvisioningTest
         $this->assertArrayHasKey("password", $result["credentials"]);
         $this->assertArrayHasKey("user", $result["credentials"]);
         $this->assertArrayHasKey("schema", $result["credentials"]);
+        $this->assertArrayHasKey("workspaceId", $result["credentials"]);
         $this->assertArrayHasKey("id", $result);
         $this->assertArrayHasKey("touch", $result);
-        $this->assertArrayHasKey("workspaceId", $result);
         $conn = $this->connect($result["credentials"]);
         $this->dbQuery($conn);
         $conn->close();
@@ -130,9 +130,9 @@ class Keboola_ProvisioningClient_RedshiftWorkspaceTest extends \ProvisioningTest
         $this->assertArrayHasKey("password", $result["credentials"]);
         $this->assertArrayHasKey("user", $result["credentials"]);
         $this->assertArrayHasKey("schema", $result["credentials"]);
+        $this->assertArrayHasKey("workspaceId", $result["credentials"]);
         $this->assertArrayHasKey("id", $result);
         $this->assertArrayHasKey("touch", $result);
-        $this->assertArrayHasKey("workspaceId", $result);
         $conn = $this->connect($result["credentials"]);
         $this->dbQuery($conn);
         $conn->close();
@@ -159,9 +159,9 @@ class Keboola_ProvisioningClient_RedshiftWorkspaceTest extends \ProvisioningTest
         $this->assertArrayHasKey("password", $result["credentials"]);
         $this->assertArrayHasKey("user", $result["credentials"]);
         $this->assertArrayHasKey("schema", $result["credentials"]);
+        $this->assertArrayHasKey("workspaceId", $result["credentials"]);
         $this->assertArrayHasKey("id", $result);
         $this->assertArrayHasKey("touch", $result);
-        $this->assertArrayHasKey("workspaceId", $result);
         $conn = $this->connect($result["credentials"]);
         $this->dbQuery($conn);
         $conn->close();
@@ -182,9 +182,9 @@ class Keboola_ProvisioningClient_RedshiftWorkspaceTest extends \ProvisioningTest
         $this->assertArrayHasKey("password", $result["credentials"]);
         $this->assertArrayHasKey("user", $result["credentials"]);
         $this->assertArrayHasKey("schema", $result["credentials"]);
+        $this->assertArrayHasKey("workspaceId", $result["credentials"]);
         $this->assertArrayHasKey("id", $result);
         $this->assertArrayHasKey("touch", $result);
-        $this->assertArrayHasKey("workspaceId", $result);
         $this->client->dropCredentials($result["id"]);
     }
 
@@ -281,7 +281,7 @@ class Keboola_ProvisioningClient_RedshiftWorkspaceTest extends \ProvisioningTest
     public function testDropWorkspace()
     {
         $result = $this->client->getCredentials();
-        $workspaceId = $result["workspaceId"];
+        $workspaceId = $result["credentials"]["workspaceId"];
         $storageApiClient = new \Keboola\StorageApi\Client([
             'url' => STORAGE_API_URL,
             'token' => PROVISIONING_API_TOKEN

--- a/tests/Keboola/Provisioning/Client/SnowflakeTest.php
+++ b/tests/Keboola/Provisioning/Client/SnowflakeTest.php
@@ -50,6 +50,9 @@ class Keboola_ProvisioningClient_SnowflakeTest extends \ProvisioningTestCase
         $this->assertArrayHasKey("workspaceId", $result["credentials"]);
         $this->assertArrayHasKey("id", $result);
         $this->assertArrayHasKey("touch", $result);
+
+        $this->assertInternalType('string', $result["credentials"]["workspaceId"]);
+
         $conn = $this->connect($result["credentials"]);
         $this->dbQuery($conn);
         odbc_close($conn);

--- a/tests/Keboola/Provisioning/Client/SnowflakeTest.php
+++ b/tests/Keboola/Provisioning/Client/SnowflakeTest.php
@@ -302,7 +302,7 @@ class Keboola_ProvisioningClient_SnowflakeTest extends \ProvisioningTestCase
         ]);
         $storageApiClient->apiDelete("storage/workspaces/{$workspaceId}");
         $result = $this->client->getCredentials();
-        $this->assertNotEquals($result["workspaceId"], $workspaceId);
+        $this->assertNotEquals($result["credentials"]["workspaceId"], $workspaceId);
     }
 
     /**

--- a/tests/Keboola/Provisioning/Client/SnowflakeTest.php
+++ b/tests/Keboola/Provisioning/Client/SnowflakeTest.php
@@ -47,8 +47,8 @@ class Keboola_ProvisioningClient_SnowflakeTest extends \ProvisioningTestCase
         $this->assertArrayHasKey("password", $result["credentials"]);
         $this->assertArrayHasKey("user", $result["credentials"]);
         $this->assertArrayHasKey("schema", $result["credentials"]);
+        $this->assertArrayHasKey("workspaceId", $result["credentials"]);
         $this->assertArrayHasKey("id", $result);
-        $this->assertArrayHasKey("workspaceId", $result);
         $this->assertArrayHasKey("touch", $result);
         $conn = $this->connect($result["credentials"]);
         $this->dbQuery($conn);
@@ -75,8 +75,8 @@ class Keboola_ProvisioningClient_SnowflakeTest extends \ProvisioningTestCase
         $this->assertArrayHasKey("password", $result["credentials"]);
         $this->assertArrayHasKey("user", $result["credentials"]);
         $this->assertArrayHasKey("schema", $result["credentials"]);
+        $this->assertArrayHasKey("workspaceId", $result["credentials"]);
         $this->assertArrayHasKey("id", $result);
-        $this->assertArrayHasKey("workspaceId", $result);
         $this->assertArrayHasKey("touch", $result);
         $conn = $this->connect($result["credentials"]);
         $this->dbQuery($conn);
@@ -103,8 +103,8 @@ class Keboola_ProvisioningClient_SnowflakeTest extends \ProvisioningTestCase
         $this->assertArrayHasKey("password", $result["credentials"]);
         $this->assertArrayHasKey("user", $result["credentials"]);
         $this->assertArrayHasKey("schema", $result["credentials"]);
+        $this->assertArrayHasKey("workspaceId", $result["credentials"]);
         $this->assertArrayHasKey("id", $result);
-        $this->assertArrayHasKey("workspaceId", $result);
         $this->assertArrayHasKey("touch", $result);
         $conn = $this->connect($result["credentials"]);
         $this->dbQuery($conn);
@@ -131,8 +131,8 @@ class Keboola_ProvisioningClient_SnowflakeTest extends \ProvisioningTestCase
         $this->assertArrayHasKey("password", $result["credentials"]);
         $this->assertArrayHasKey("user", $result["credentials"]);
         $this->assertArrayHasKey("schema", $result["credentials"]);
+        $this->assertArrayHasKey("workspaceId", $result["credentials"]);
         $this->assertArrayHasKey("id", $result);
-        $this->assertArrayHasKey("workspaceId", $result);
         $this->assertArrayHasKey("touch", $result);
         $conn = $this->connect($result["credentials"]);
         $this->dbQuery($conn);
@@ -185,8 +185,8 @@ class Keboola_ProvisioningClient_SnowflakeTest extends \ProvisioningTestCase
         $this->assertArrayHasKey("password", $result["credentials"]);
         $this->assertArrayHasKey("user", $result["credentials"]);
         $this->assertArrayHasKey("schema", $result["credentials"]);
+        $this->assertArrayHasKey("workspaceId", $result["credentials"]);
         $this->assertArrayHasKey("id", $result);
-        $this->assertArrayHasKey("workspaceId", $result);
         $this->assertArrayHasKey("touch", $result);
         $conn = $this->connect($result["credentials"]);
         $this->dbQuery($conn);
@@ -209,8 +209,8 @@ class Keboola_ProvisioningClient_SnowflakeTest extends \ProvisioningTestCase
         $this->assertArrayHasKey("user", $result["credentials"]);
         $this->assertArrayHasKey("schema", $result["credentials"]);
         $this->assertArrayHasKey("warehouse", $result["credentials"]);
+        $this->assertArrayHasKey("workspaceId", $result["credentials"]);
         $this->assertArrayHasKey("id", $result);
-        $this->assertArrayHasKey("workspaceId", $result);
         $this->assertArrayHasKey("touch", $result);
         $this->client->dropCredentials($result["id"]);
     }
@@ -295,7 +295,7 @@ class Keboola_ProvisioningClient_SnowflakeTest extends \ProvisioningTestCase
     public function testDropWorkspace()
     {
         $result = $this->client->getCredentials();
-        $workspaceId = $result["workspaceId"];
+        $workspaceId = $result["credentials"]["workspaceId"];
         $storageApiClient = new \Keboola\StorageApi\Client([
             'url' => STORAGE_API_URL,
             'token' => PROVISIONING_API_TOKEN


### PR DESCRIPTION
FIXES #21 

Jsou to spíš kosmetický fixy.

- **nekontroluje** se jestli vrácený `workspaceId` je číslo nebo string (https://github.com/keboola/internal/issues/127#issuecomment-468251534)
- upravil jsem api blueprint
- `workspaceId` se vrací pouze v node `credentials` (tam sice logicky nepatří a chtěl jsem ho vyhodit ven, ale na to teď kašlu)
- `id` je furt duplicitně v rootu i `credentials`